### PR TITLE
photon: change base image to debian:bullseye-slim

### DIFF
--- a/geocoder/photon/Dockerfile
+++ b/geocoder/photon/Dockerfile
@@ -1,20 +1,9 @@
-FROM ubuntu:jammy
-
-RUN apt-get update
-
-RUN apt-get install -y tzdata
+FROM debian:bullseye-slim
 
 ENV TZ="America/New_York"
 
-RUN apt-get install -y postgresql postgis curl openjdk-8-jre sudo
-
-RUN mkdir /nominatim_data
-
-COPY data.nominatim.tgz /nominatim_data/data.nominatim.tgz
-
-WORKDIR /nominatim_data
-
-RUN tar xvf data.nominatim.tgz
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends postgresql postgis postgresql-postgis curl openjdk-11-jre-headless sudo
 
 RUN mkdir /photon
 
@@ -24,16 +13,27 @@ RUN useradd -ms /bin/bash photon
 
 RUN chown photon /photon
 
-RUN curl -LJO https://github.com/komoot/photon/releases/download/0.3.5/photon-0.3.5.jar
+ARG PHOTON_VERSION=0.3.5
+ARG PHOTON_HASH=6f438e905b020a70ec54de47b7c7f8b9c7921ef0ee84a3a9e0a6a6ebb7f74fa8
 
-RUN echo '6f438e905b020a70ec54de47b7c7f8b9c7921ef0ee84a3a9e0a6a6ebb7f74fa8  ./photon-0.3.5.jar' | sha256sum --check
+RUN curl -L -o ./photon.jar https://github.com/komoot/photon/releases/download/${PHOTON_VERSION}/photon-${PHOTON_VERSION}.jar
+
+RUN echo "${PHOTON_HASH}  ./photon.jar" | sha256sum --check
 
 COPY import_from_dump.sh /photon
 
 USER root
 
+COPY data.nominatim.tgz /nominatim_data/data.nominatim.tgz
+
+WORKDIR /nominatim_data
+
+RUN tar xvf data.nominatim.tgz
+
+WORKDIR /photon
+
 RUN ["/bin/bash", "/photon/import_from_dump.sh"]
 
 USER photon
 
-CMD [ "java", "-jar", "photon-0.3.5.jar" ]
+CMD [ "java", "-jar", "photon.jar" ]

--- a/geocoder/photon/import_from_dump.sh
+++ b/geocoder/photon/import_from_dump.sh
@@ -14,6 +14,6 @@ sudo -E -u postgres psql postgres -c "CREATE DATABASE nominatim"
 
 sudo -E -u postgres psql nominatim < /nominatim_data/nominatim
 
-sudo -u photon /bin/sh -c 'java -jar photon-*.jar -nominatim-import -host localhost -port 5432 -database nominatim -user nominatim -password password1 -languages es,fr,de,en'
+sudo -u photon /bin/sh -c 'java -jar photon.jar -nominatim-import -host localhost -port 5432 -database nominatim -user nominatim -password password1 -languages es,fr,de,en'
 
 # TODO delete the postgres db to save disk space.


### PR DESCRIPTION
In order to use common base image. Note that tzdata is already installed in the new base image.

* upgrade openjdk from 8 to 11
* Add build args `PHOTON_VERSION` and `PHOTON_HASH`
* Strip version suffix from jar filename