### PR TITLE
Web env config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,5 +17,13 @@ services:
     - "headway_graphhopper_vol:/graph_volume"
   nginx:
     image: headway_nginx
+    environment:
+      HEADWAY_PUBLIC_URL: http://127.0.0.1:8080
+      HEADWAY_HTTP_PORT: 8080
+      HEADWAY_RESOLVER: 127.0.0.11
+      HEADWAY_GRAPHHOPPER_URL: http://graphhopper:8989
+      HEADWAY_NOMINATIM_URL: http://nominatim:8080
+      HEADWAY_PHOTON_URL: http://photon:2322
+      HEADWAY_TILESERVER_URL: http://mbtileserver:8000
     ports:
     - "8080:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,18 +5,23 @@ volumes:
 services:
   mbtileserver:
     image: headway_tileserver
+    build: ./tileserver
     environment:
       PORT: 8000
   photon:
     image: headway_photon
+    build: ./geocoder/photon
   nominatim:
     image: headway_nominatim
+    build: ./geocoder/nominatim
   graphhopper:
     image: headway_graphhopper
+    build: ./graphhopper
     volumes:
     - "headway_graphhopper_vol:/graph_volume"
   nginx:
     image: headway_nginx
+    build: ./web
     environment:
       HEADWAY_PUBLIC_URL: http://127.0.0.1:8080
       HEADWAY_HTTP_PORT: 8080

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,8 +13,17 @@ FROM nginx
 
 COPY --from=builder /frontend/dist/spa/ /usr/share/nginx/html/
 
-COPY nginx.conf .base_url /etc/nginx/
+COPY nginx.conf.template /etc/nginx/templates/nginx.conf.template
 
 COPY bbox.txt /usr/share/nginx/html/bbox.txt
 
-RUN bash -c 'sed -i "s^__HEADWAY_BASE_URL__^$(</etc/nginx/.base_url)^" /etc/nginx/nginx.conf'
+ENV HEADWAY_PUBLIC_URL=http://127.0.0.1:8080
+ENV HEADWAY_HTTP_PORT=8080
+ENV HEADWAY_RESOLVER=127.0.0.11
+ENV HEADWAY_GRAPHHOPPER_URL=http://graphhopper:8989
+ENV HEADWAY_PHOTON_URL=http://photon:2322
+ENV HEADWAY_TILESERVER_URL=http://mbtileserver:8000
+ENV HEADWAY_NOMINATIM_URL=http://nominatim:8080
+# for escaping $ in nginx template
+ENV ESC=$
+ENV NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -18,53 +18,53 @@ http {
   proxy_http_version 1.1;
 
   server {
-    resolver 127.0.0.11;
-    listen 8080 default_server;
+    resolver ${HEADWAY_RESOLVER};
+    listen ${HEADWAY_HTTP_PORT} default_server;
 
     # nominatim
     location ~ /nominatim/lookup/([NRW][0-9]+)  {
-      proxy_pass      http://nominatim:8080/lookup?osm_ids=$1;
+      proxy_pass      ${HEADWAY_NOMINATIM_URL}/lookup?osm_ids=${ESC}1;
     }
 
     # photon
     location /photon/  {
-      proxy_pass      http://photon:2322/;
+      proxy_pass      ${HEADWAY_PHOTON_URL}/;
     }
 
     # graphhopper
     location /graphhopper/  {
-      proxy_pass      http://graphhopper:8989/;
+      proxy_pass      ${HEADWAY_GRAPHHOPPER_URL};
     }
 
     # mbtileserver stuff
     location /data/  {
       proxy_set_header Accept-Encoding "";
-      proxy_set_header x-real-IP $remote_addr;
-      proxy_set_header x-forwarded-for $proxy_add_x_forwarded_for;
+      proxy_set_header x-real-IP ${ESC}remote_addr;
+      proxy_set_header x-forwarded-for ${ESC}proxy_add_x_forwarded_for;
       proxy_set_header Host "magic_string_magic";
       sub_filter_types application/json;
-      sub_filter_once off;
-      sub_filter 'http://magic_string_magic' '__HEADWAY_BASE_URL__';
-      proxy_pass      http://mbtileserver:8000;
+      sub_filter_once  off;
+      sub_filter       'http://magic_string_magic' '${HEADWAY_PUBLIC_URL}';
+      proxy_pass       ${HEADWAY_TILESERVER_URL}/data/;
     }
     location /styles/  {
       proxy_set_header Accept-Encoding "";
-      proxy_set_header x-real-IP $remote_addr;
+      proxy_set_header x-real-IP ${ESC}remote_addr;
       proxy_set_header x-forwarded-for $proxy_add_x_forwarded_for;
       proxy_set_header Host "magic_string_magic";
       sub_filter_types application/json;
-      sub_filter_once off;
-      sub_filter 'http://magic_string_magic' '__HEADWAY_BASE_URL__';
-      proxy_pass      http://mbtileserver:8000;
+      sub_filter_once  off;
+      sub_filter       'http://magic_string_magic' '${HEADWAY_PUBLIC_URL}';
+      proxy_pass       ${HEADWAY_TILESERVER_URL};
     }
     location /fonts/  {
       proxy_set_header Accept-Encoding "";
-      proxy_set_header x-real-IP $remote_addr;
+      proxy_set_header x-real-IP ${ESC}remote_addr;
       proxy_set_header x-forwarded-for $proxy_add_x_forwarded_for;
-      proxy_pass      http://mbtileserver:8000;
+      proxy_pass       ${HEADWAY_TILESERVER_URL}/fonts/;
     }
     location / {
-      try_files $uri /index.html;
+      try_files ${ESC}uri /index.html;
     }
   }
 }


### PR DESCRIPTION
This should make the image usable independently from the specific docker-compose setup in the repo.

- Allows overriding web container configuration via env vars:
  -   `HEADWAY_PUBLIC_URL`
  -  `HEADWAY_HTTP_PORT`
  -    `HEADWAY_RESOLVER`
  -   `HEADWAY_GRAPHHOPPER_URL`
  -  `HEADWAY_NOMINATIM_URL`
   - `HEADWAY_PHOTON_URL`
   - `HEADWAY_TILESERVER_URL`
- Adds `build` directive to `docker-compose.yaml` to facilitate building images via `docker-compose build`

Note I had to add suffixes [`/data`](https://github.com/ellenhp/headway/compare/main...3nprob:web-env-config?expand=1#diff-af6bd4d7c8c60522ef8b9f2dfb92eb0e2a179dc172e33e527ced4996a8291a2eR48) and `/fonts` to get the requests route properly to the upstream containers - doesn't seem to be related to the templating change though.